### PR TITLE
Use constructor with highest number of params instead of lowest

### DIFF
--- a/src/main/java/org/synyx/beanfiller/strategies/JustAnotherBeanStrategy.java
+++ b/src/main/java/org/synyx/beanfiller/strategies/JustAnotherBeanStrategy.java
@@ -57,9 +57,10 @@ public class JustAnotherBeanStrategy extends AbstractCreatorStrategy {
                 + " And we also could not find a constructor!");
         }
 
-        declaredConstructors.sort(Comparator.comparingInt(Constructor::getParameterCount));
-
-        Constructor declaredConstructor = declaredConstructors.get(0);
+        // use constructor with most parameters to potentially set the most final fields
+        Constructor declaredConstructor = declaredConstructors.stream()
+                .max(Comparator.comparingInt(Constructor::getParameterCount))
+                .orElse(null);
 
         try {
             declaredConstructor.setAccessible(true);

--- a/src/test/java/org/synyx/beanfiller/strategies/JustAnotherBeanStrategyTest.java
+++ b/src/test/java/org/synyx/beanfiller/strategies/JustAnotherBeanStrategyTest.java
@@ -45,7 +45,7 @@ public class JustAnotherBeanStrategyTest {
 
 
     @Test
-    public void testTakesTheConstructorWithTheLeastNumberOfParameters() throws FillingException {
+    public void testTakesTheConstructorWithTheHighestNumberOfParameters() throws FillingException {
 
         JustAnotherBeanStrategy strategy = setupStrategy();
 
@@ -53,7 +53,7 @@ public class JustAnotherBeanStrategyTest {
                     MultipleConstructorsObject.class, null, null, null, null, null));
         assertThat(object, notNullValue());
         assertThat(object.getFoo(), notNullValue());
-        assertThat(object.getBar(), nullValue());
+        assertThat(object.getBar(), notNullValue());
     }
 
 


### PR DESCRIPTION
* To potentially set the most final fields of the object, we have to use the constructor with the most params