### PR TITLE
Don't use copy constructors, as they will cause a stackoverflow

### DIFF
--- a/src/main/java/org/synyx/beanfiller/strategies/JustAnotherBeanStrategy.java
+++ b/src/main/java/org/synyx/beanfiller/strategies/JustAnotherBeanStrategy.java
@@ -59,8 +59,19 @@ public class JustAnotherBeanStrategy extends AbstractCreatorStrategy {
 
         // use constructor with most parameters to potentially set the most final fields
         Constructor declaredConstructor = declaredConstructors.stream()
+                .filter(constructor ->
+                        // filter copy constructors as they will cause a stackoverflow
+                    !Arrays.asList(constructor.getParameterTypes()).contains(parentClazz)
+                )
                 .max(Comparator.comparingInt(Constructor::getParameterCount))
                 .orElse(null);
+
+        if(declaredConstructor==null){
+                throw new FillingException("There was no Creator set for the class " + parentClazz.getName()
+                        + " So we tried to instantiate it via constructor, but couldn't find a usable constructor. "
+                        + "Please provide at least a private empty constructor for usage. "
+                        + "Copy constructors will not be used.");
+        }
 
         try {
             declaredConstructor.setAccessible(true);

--- a/src/test/java/org/synyx/beanfiller/strategies/JustAnotherBeanStrategyTest.java
+++ b/src/test/java/org/synyx/beanfiller/strategies/JustAnotherBeanStrategyTest.java
@@ -1,26 +1,22 @@
 package org.synyx.beanfiller.strategies;
 
-import org.hamcrest.MatcherAssert;
 import org.junit.Test;
-
 import org.synyx.beanfiller.BeanFiller;
 import org.synyx.beanfiller.domain.ObjectInformation;
 import org.synyx.beanfiller.exceptions.FillingException;
 import org.synyx.beanfiller.services.CreatorRegistry;
-import org.synyx.beanfiller.testobjects.MultipleConstructorsObject;
-import org.synyx.beanfiller.testobjects.NoDefaultConstructorObject;
-import org.synyx.beanfiller.testobjects.PrivateConstructorObject;
+import org.synyx.beanfiller.testobjects.*;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.notNullValue;
-import static org.hamcrest.Matchers.nullValue;
-
+import static org.hamcrest.Matchers.*;
+import static org.synyx.beanfiller.testobjects.CopyConstructorObjectWithPrivateConstructor.COPY_CONSTRUCTOR_USED_VALUE;
 
 
 /**
  * @author  Tobias Knell - knell@synyx.de
  */
 public class JustAnotherBeanStrategyTest {
+
 
     @Test
     public void testPrivateConstructor() throws FillingException {
@@ -54,6 +50,29 @@ public class JustAnotherBeanStrategyTest {
         assertThat(object, notNullValue());
         assertThat(object.getFoo(), notNullValue());
         assertThat(object.getBar(), notNullValue());
+    }
+
+    @Test(expected = FillingException.class)
+    public void failsWhenOnlyCopyConstructorIsAvailable() throws FillingException {
+
+        JustAnotherBeanStrategy strategy = setupStrategy();
+
+        strategy.createObject(new ObjectInformation(
+                CopyConstructorObject.class, null, null, null, null, null));
+    }
+
+    @Test
+    public void usesPrivateConstructorOverCopyConstructor() throws FillingException {
+
+        assertThat(new CopyConstructorObjectWithPrivateConstructor(null).getValue(), is(COPY_CONSTRUCTOR_USED_VALUE));
+
+        JustAnotherBeanStrategy strategy = setupStrategy();
+
+        CopyConstructorObjectWithPrivateConstructor object = (CopyConstructorObjectWithPrivateConstructor)
+                strategy.createObject(new ObjectInformation(CopyConstructorObjectWithPrivateConstructor.class, null, null, null, null, null));
+        assertThat(object, notNullValue());
+
+        assertThat(object.getValue(), is(not(COPY_CONSTRUCTOR_USED_VALUE)));
     }
 
 

--- a/src/test/java/org/synyx/beanfiller/testobjects/CopyConstructorObject.java
+++ b/src/test/java/org/synyx/beanfiller/testobjects/CopyConstructorObject.java
@@ -1,0 +1,7 @@
+package org.synyx.beanfiller.testobjects;
+
+public class CopyConstructorObject {
+    public CopyConstructorObject(CopyConstructorObject copy){
+    }
+
+}

--- a/src/test/java/org/synyx/beanfiller/testobjects/CopyConstructorObjectWithPrivateConstructor.java
+++ b/src/test/java/org/synyx/beanfiller/testobjects/CopyConstructorObjectWithPrivateConstructor.java
@@ -1,0 +1,23 @@
+package org.synyx.beanfiller.testobjects;
+
+public class CopyConstructorObjectWithPrivateConstructor {
+    public static final String COPY_CONSTRUCTOR_USED_VALUE = "copy constructor used";
+
+    private String value;
+
+    private CopyConstructorObjectWithPrivateConstructor(){
+        // private for filling
+    }
+
+    public CopyConstructorObjectWithPrivateConstructor(CopyConstructorObjectWithPrivateConstructor copy){
+        this.value = COPY_CONSTRUCTOR_USED_VALUE;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public void setValue(String value) {
+        this.value = value;
+    }
+}


### PR DESCRIPTION
* As the Beanfiller defaults to the same constructor each time, it tries to create another object with the same copy constructor until the program reaches a stackoverflow
* Copy constructors (more specifically constructors with the same object that should be created as parameter) will no longer be used
* When the only available constructor is a copy constructor, there will now be an exception that another constructor must be provided